### PR TITLE
Workflow - Path Exclusion and Linux Job

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,19 +5,33 @@ name: Swift
 
 on:
   push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'CONTRIBUTORS.txt'
     branches: [ "main", "develop" ]
   pull_request:
     branches: [ "main", "develop" ]
 
 jobs:
-  build:
+  build-macos:
     name: Swift build and test
-# TODO: add ubuntu
-#    runs-on: [ubuntu-latest, macos-latest]
     runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v
+
+  build-linux:
+    name: Linux build and test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: swift-actions/setup-swift@v1
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Prevent workflows from running when we directly edit README, CONTRIBUTORS and LICENSE docs

Added a linux build and test job that runs on Ubuntu.

> **Note**
> The [setup-swift](https://github.com/marketplace/actions/setup-swift) action page for reference