### PR TITLE
Preliminary Key Update Support

### DIFF
--- a/Sources/Quic/NIO/Connection/ByteBuffer+Decoding.swift
+++ b/Sources/Quic/NIO/Connection/ByteBuffer+Decoding.swift
@@ -357,6 +357,48 @@ extension ByteBuffer {
             return nil
         }
     }
+
+    mutating func readEncryptedQuicTrafficHeader(dcid: ConnectionID, using keys: PacketProtector) -> GenericShortHeader? {
+        // Grab the first byte
+        guard let protectedFirstByte = self.getBytes(at: self.readerIndex, length: 1)?.first else { print("No bytes available to Read"); return nil }
+        // Ensure the first byte indicates that this is an Initial Packet Type
+        guard HeaderForm(rawValue: protectedFirstByte & HeaderForm.mask) == .short else { print("Not a Traffic Packet"); return nil }
+        do {
+            // Get the Packet Length
+            let pno = 1 + dcid.length
+            guard let bytes = self.getBytes(at: self.readerIndex, length: self.readableBytes) else { print("Not Enough Bytes Available"); return nil }
+
+            let sampleOffset = pno + 4
+            guard let sample = self.getBytes(at: self.readerIndex + sampleOffset, length: 16) else { print("Not Enough Bytes Available For Sample"); return nil }
+            var hb = Array(bytes[..<(pno + 4)])
+            try keys.removeHeaderProtection(sample: sample, headerBytes: &hb, packetNumberOffset: pno)
+
+            var headerBuf = ByteBuffer(bytes: hb)
+            guard let firstByte = headerBuf.readBytes(length: 1)?.first, HeaderForm(rawValue: firstByte & HeaderForm.mask) == .short else { print("Not a TrafficPacket"); return nil }
+            guard dcid.rawValue == headerBuf.readBytes(length: dcid.length) else { print("Failed to consume DCID from Header"); return nil }
+            guard let packetNumber = headerBuf.readBytes(length: headerBuf.readableBytes) else { print("Failed to consume PacketNumber from Header"); return nil }
+
+            let header = GenericShortHeader(firstByte: firstByte, id: dcid, packetNumber: packetNumber)
+            self.moveReaderIndex(forwardBy: hb.count)
+
+            return header
+        } catch {
+            print("Failed to read header for Short Packet: \(error)")
+            return nil
+        }
+    }
+
+    mutating func readEncryptedQuicTrafficPayload(header: GenericShortHeader, using keys: PacketProtector) -> ShortPacket? {
+        do {
+            let decryptedPayload = try keys.decryptPayload(Array(self.readableBytesView), packetNumber: header.packetNumber, authenticatingData: header.bytes)
+            let packet = try ShortPacket(header: header, payload: decryptedPayload.parsePayloadIntoFrames().frames)
+            self.moveReaderIndex(forwardBy: decryptedPayload.count + keys.suite!.tagLength)
+            return packet
+        } catch {
+            print("Failed to decrypt payload for Short Packet: \(error)")
+            return nil
+        }
+    }
 }
 
 extension ByteBuffer {

--- a/Sources/Quic/NIO/Connection/ConnectionMuxer.swift
+++ b/Sources/Quic/NIO/Connection/ConnectionMuxer.swift
@@ -974,3 +974,41 @@ extension QuicConnectionChannel: Hashable {
         hasher.combine(ObjectIdentifier(self))
     }
 }
+
+/// QUIC Connection Channel Events.
+enum ConnectionChannelEvent {
+
+    /// Traffic / Appliction Key Update Initiated
+    ///
+    /// Intended Event Propogation
+    /// ```
+    /// PacketProtectorHandler -> AckHandler -> StateHandler
+    /// ```
+    struct KeyUpdateInitiated: Hashable, Sendable {
+        /// The packetNumber at which the Key Update was initiated
+        public var packetNumber: UInt64
+
+        /// The initiator of the Key Update (client or server)
+        public var initiator: EndpointRole
+
+        public init(packetNumber: UInt64, initiator: EndpointRole) {
+            self.packetNumber = packetNumber
+            self.initiator = initiator
+        }
+    }
+
+    /// Traffic / Appliction Key Update Finished
+    ///
+    /// Intended Event Propogation
+    /// ```
+    /// AckHandler -> StateHandler
+    /// ```
+    struct KeyUpdateFinished: Hashable, Sendable {
+        /// The packetNumber at which the Key Update was completed
+        public var packetNumber: UInt64
+
+        public init(packetNumber: UInt64) {
+            self.packetNumber = packetNumber
+        }
+    }
+}

--- a/Sources/Quic/QuicTypes/ByteFragments/HeaderFragments/KeyPhase.swift
+++ b/Sources/Quic/QuicTypes/ByteFragments/HeaderFragments/KeyPhase.swift
@@ -1,11 +1,31 @@
-//  Copyright Kenneth Laskoski. All Rights Reserved.
-//  SPDX-License-Identifier: Apache-2.0
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftQUIC open source project
+//
+// Copyright (c) 2023 the SwiftQUIC project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftQUIC project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 
 enum KeyPhase: UInt8 {
-  case not = 0b0000_0000
-  case yes = 0b0000_0100
+    case not = 0b0000_0000
+    case yes = 0b0000_0100
 }
 
 extension KeyPhase: ByteFragment {
-  static let mask: UInt8 = 0b0000_0100
+    static let mask: UInt8 = 0b0000_0100
+
+    mutating func toggle() {
+        switch self {
+            case .not:
+                self = .yes
+            case .yes:
+                self = .not
+        }
+    }
 }

--- a/Sources/Quic/QuicTypes/ByteFragments/StreamIDFragments/EndpointRole.swift
+++ b/Sources/Quic/QuicTypes/ByteFragments/StreamIDFragments/EndpointRole.swift
@@ -1,11 +1,31 @@
-//  Copyright Kenneth Laskoski. All Rights Reserved.
-//  SPDX-License-Identifier: Apache-2.0
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftQUIC open source project
+//
+// Copyright (c) 2023 the SwiftQUIC project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftQUIC project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 
 enum EndpointRole: UInt8 {
-  case client = 0
-  case server = 1
+    case client = 0
+    case server = 1
 }
 
 extension EndpointRole: ByteFragment {
-  static let mask: UInt8 = 1
+    static let mask: UInt8 = 1
+}
+
+extension EndpointRole {
+    var opposite: EndpointRole {
+        switch self {
+            case .client: return .server
+            case .server: return .client
+        }
+    }
 }

--- a/Sources/Quic/QuicTypes/Packets/Header.swift
+++ b/Sources/Quic/QuicTypes/Packets/Header.swift
@@ -64,21 +64,11 @@ extension NumberedHeader {
     var packetNumberLengthByteCount: UInt8 {
         return UInt8(self.packetNumber.count)
     }
-}
 
-//extension LongHeader where Self:NumberedPacket {
-//    func bytes() -> [UInt8] {
-//        var bytes:[UInt8] = []
-//        bytes.append(self.firstByte)
-//        bytes.append(contentsOf: self.version.bytes)
-//        bytes.append(contentsOf: writeQuicVarInt(UInt64(self.destinationIDLength)))
-//        bytes.append(contentsOf: self.destinationID.rawValue)
-//        bytes.append(contentsOf: writeQuicVarInt(UInt64(self.sourceIDLength)))
-//        bytes.append(contentsOf: self.sourceID.rawValue)
-//        bytes.append(contentsOf: self.packetNumber)
-//        return bytes
-//    }
-//}
+    func packetNumberAsUInt64() -> UInt64 {
+        UInt64(bytes: (Array<UInt8>(repeating: 0, count: 8 - packetNumber.count) + packetNumber).reversed())
+    }
+}
 
 extension Header {
     var needsPacketProtection: Bool {

--- a/Sources/Quic/QuicTypes/Packets/Short.swift
+++ b/Sources/Quic/QuicTypes/Packets/Short.swift
@@ -34,6 +34,15 @@ struct GenericShortHeader: ShortHeader, NumberedHeader {
     mutating func setPacketNumber(_ pn: [UInt8]) {
         self.packetNumber = pn
     }
+
+    mutating func setKeyPhaseBit(_ kp: KeyPhase) {
+        switch kp {
+            case .yes:
+                self.firstByte |= kp.rawValue
+            case .not:
+                self.firstByte &= 0b11111011
+        }
+    }
 }
 
 struct ShortPacket: Packet, NumberedPacket {

--- a/Sources/Quic/QuicTypes/Version/Version+KeyGen.swift
+++ b/Sources/Quic/QuicTypes/Version/Version+KeyGen.swift
@@ -70,6 +70,8 @@ extension Version {
 
     static private let HKDF_LABEL_KEY_V1 = "quic key"
     static private let HKDF_LABEL_KEY_V2 = "quicv2 key"
+    static private let HKDF_LABEL_KEY_V1_UPDATE = "quic ku"
+    static private let HKDF_LABEL_KEY_V2_UPDATE = "quicv2 ku"
 
     /// Traffic Protection Key Generation Label
     /// - Note: To be used along side the `HKDF` to generate the `Key` used to initialize the `AES.Cipher` for packet protection.
@@ -79,6 +81,15 @@ extension Version {
                 return Version.HKDF_LABEL_KEY_V2
             default:
                 return Version.HKDF_LABEL_KEY_V1
+        }
+    }
+
+    public var hkdfTrafficProtectionUpdateLabel: String {
+        switch self {
+            case .version2:
+                return Version.HKDF_LABEL_KEY_V2_UPDATE
+            default:
+                return Version.HKDF_LABEL_KEY_V1_UPDATE
         }
     }
 


### PR DESCRIPTION
## Preliminary Support for Key Updates
[As described in RFC9001 - Section 6](https://datatracker.ietf.org/doc/html/rfc9001#section-6)

### What
This PR adds preliminary support for traffic / application key updates throughout the lifecycle of a connection.

### How
1) The `PacketProtectorHandler` monitors the `KeyPhase` bit in short/traffic headers and initiates a Key Update upon a noticed change. 
2) The `PacketProtectorHandler` fires a `KeyUpdateInitiated` event along the pipeline. 
3) This event is picked up by the `ACKHandler` at which point the `ACKHandler` creates a in-flight packet datum / checkpoint which it uses to ensure all in-flight packets (those that were encrypted with the previous keys) have been acknowledged. 
4) Once the `ACKHandler` determines all in-flight packets (at the time of the key update) have been acknowledged, it fires a `KeyUpdateFinished` event along the pipeline.
5) The `StateHandler` (Client / Server Handlers) listen for, and absorb, both the `KeyUpdateInitiated` and `KeyUpdateFinished` events. 
6) Upon receiving a `KeyUpdateFinish` event the `StateHandler` requests the `PacketProtectorHandler` drop the keys belonging to the previous phase.
7) This marks the end of a Key Update cycle.

### Testing it
Using the Go example code provided in the [Go Client Handshake Test](https://github.com/swift-quic/swift-quic/blob/develop/Tests/QuicTests/NIOTests/GoInteropTests/QuicServerGoClientHandshakeTests.swift) file. The Go Client will initiate a key update after sending approximately 100 packets. The swift server should respond to the key update successfully and drop the previous keys once it's deemed safe to do so. You can search the console logs for "key update" for more info. 