### PR TITLE
Version negotiation

### DIFF
--- a/Sources/Quic/NIO/Connection/ByteBuffer+Decoding.swift
+++ b/Sources/Quic/NIO/Connection/ByteBuffer+Decoding.swift
@@ -601,6 +601,31 @@ extension ByteBuffer {
         return result
     }
 
+    mutating func readVersionNegotiationPacket() -> VersionNegotiationPacket? {
+        self.rewindReaderOnNil { `self` -> VersionNegotiationPacket? in
+            // The first byte only tells us that it's a Long Form Header (1st bit, the last 7 bits are unused / artbitrary)
+            guard let firstByte = self.readBytes(length: 1)?.first else { return nil }
+            let form = HeaderForm(rawValue: firstByte & HeaderForm.mask)
+            guard case .long = form else { return nil }
+
+            // The fact that the Version is set to 0 is the indicating factor that this is a Version negotiation packet
+            guard let version = self.readVersion() else { return nil }
+            guard version.rawValue == 0 else { return nil }
+
+            guard let dcid = self.readConnectionID() else { return nil }
+            guard let scid = self.readConnectionID() else { return nil }
+
+            var supportedVersions: [Version] = []
+            while self.readableBytes > 0, let v = self.readVersion() {
+                supportedVersions.append(v)
+            }
+
+            guard self.readableBytes == 0 else { return nil }
+
+            return VersionNegotiationPacket(destinationID: dcid, sourceID: scid, supportedVersions: supportedVersions)
+        }
+    }
+
     //    // https://www.rfc-editor.org/rfc/rfc9000.html#name-sample-variable-length-inte
     //    func readQuicVarInt() -> (bytesRead: Int, value: UInt64)? {
     //

--- a/Sources/Quic/NIO/Connection/ConnectionMuxer.swift
+++ b/Sources/Quic/NIO/Connection/ConnectionMuxer.swift
@@ -996,10 +996,10 @@ enum ConnectionChannelEvent {
     /// ```
     struct KeyUpdateInitiated: Hashable, Sendable {
         /// The packetNumber at which the Key Update was initiated
-        public var packetNumber: UInt64
+        public let packetNumber: UInt64
 
         /// The initiator of the Key Update (client or server)
-        public var initiator: EndpointRole
+        public let initiator: EndpointRole
 
         public init(packetNumber: UInt64, initiator: EndpointRole) {
             self.packetNumber = packetNumber
@@ -1015,10 +1015,40 @@ enum ConnectionChannelEvent {
     /// ```
     struct KeyUpdateFinished: Hashable, Sendable {
         /// The packetNumber at which the Key Update was completed
-        public var packetNumber: UInt64
+        public let packetNumber: UInt64
 
         public init(packetNumber: UInt64) {
             self.packetNumber = packetNumber
+        }
+    }
+
+    /// Version Negotiation Event
+    ///
+    /// Intended Event Propogation
+    /// ```
+    /// PacketProtectorHandler -> StateHandler
+    /// ```
+    struct VersionNegotiated: Hashable, Sendable {
+        /// The Version that was negotiated
+        public let version: Version
+
+        public init(version: Version) {
+            self.version = version
+        }
+    }
+
+    /// Failed Version Negotiation Event
+    ///
+    /// Intended Event Propogation
+    /// ```
+    /// PacketProtectorHandler -> StateHandler
+    /// ```
+    struct FailedVersionNegotiation: Hashable, Sendable {
+        /// The error encountered while attempting to negotiate a support Version
+        public let error: String
+
+        public init(error: String) {
+            self.error = error
         }
     }
 }

--- a/Sources/Quic/NIO/Connection/ConnectionMuxer.swift
+++ b/Sources/Quic/NIO/Connection/ConnectionMuxer.swift
@@ -79,6 +79,7 @@ final class QuicConnectionMultiplexer: ChannelInboundHandler, ChannelOutboundHan
             if !channel.inList {
                 self.didReadChannels.append(channel)
             }
+
             // Otherwise we need to mux on the DCID of the Traffic packet
         } else if let connection = connections.first(where: { $0.value.hasActiveDCIDFor(envelope.data) }) {
             // Update the socket address in our dictionary
@@ -91,16 +92,25 @@ final class QuicConnectionMultiplexer: ChannelInboundHandler, ChannelOutboundHan
             if !connection.value.inList {
                 self.didReadChannels.append(connection.value)
             }
+
             // If there are no matches for open connections, check to see if it's a valid InitialPacket and proceed to open a new connection
         } else {
             guard let firstByte = envelope.data.getBytes(at: 0, length: 1)?.first else { print("QuicConnectionMultiplexer::No Bytes Available"); return }
             guard PacketType(firstByte) == .Initial else { print("QuicConnectionMultiplexer::First Byte doesn't indicate an InitialPacket"); return }
             guard let version = envelope.data.getVersion(at: 1) else { print("QuicConnectionMultiplexer::Failed to read Version"); return }
-            guard isSupported(version: version) else { print("QuicConnectionMultiplexer::Unsupported Version \(version)"); return }
             guard let dcid = envelope.data.getConnectionID(at: 5) else { print("QuicConnectionMultiplexer::Failed to read DCID"); return }
             let scid: ConnectionID? = envelope.data.getConnectionID(at: 5 + dcid.lengthPrefixedBytes.count)
 
-            // Open a new connection
+            // Ensure we support this version. Otherwise we respond with a VersionNegotiationPacket.
+            guard isSupported(version: version) else {
+                print("QuicConnectionMultiplexer::Unsupported Version `\(version)`")
+                print("Sending Version Negotiation Packet")
+                let vnPacket = VersionNegotiationPacket(destinationID: scid ?? ConnectionID(), sourceID: dcid)
+                let envelope = AddressedEnvelope(remoteAddress: envelope.remoteAddress, data: ByteBuffer(bytes: vnPacket.headerBytes + vnPacket.serializedPayload))
+                return context.writeAndFlush(self.wrapOutboundOut(envelope), promise: nil)
+            }
+
+            // Everything looks good, let's open a new connection...
             print("Opening new Channel for \(envelope.remoteAddress)")
 
             let channel = QuicConnectionChannel(allocator: self.channel.allocator, parent: self.channel, multiplexer: self, remoteAddress: envelope.remoteAddress)

--- a/Sources/Quic/NIO/Connection/Handlers/ClientHandler.swift
+++ b/Sources/Quic/NIO/Connection/Handlers/ClientHandler.swift
@@ -262,7 +262,7 @@ final class QUICClientHandler: ChannelDuplexHandler, NIOSSLQuicDelegate {
                         guard var encryptedExtensions = frameBuf.readTLSEncryptedExtensions() else { print("QUICClientHandler::ChannelRead::Expected EncryptedExtensions Frame, didn't get it"); return }
                         guard let certificate = frameBuf.readTLSCertificate() else { print("QUICClientHandler::ChannelRead::Expected Certificate Frame, didn't get it"); return }
 
-                        let quicParamsOffset = encryptedExtensions.firstRange(of: [0x00, 0x39])!
+                        guard let quicParamsOffset = encryptedExtensions.firstRange(of: [0x00, 0x39]) ?? encryptedExtensions.firstRange(of: [0xff, 0xa5]) else { fatalError("Failed to extract QUIC Params") }
                         var extBuf = ByteBuffer(bytes: encryptedExtensions.dropFirst(quicParamsOffset.startIndex + 4))
                         print(encryptedExtensions.hexString)
                         print(extBuf.readableBytesView.hexString)

--- a/Sources/Quic/NIO/Connection/Handlers/PacketProtectorHandler.swift
+++ b/Sources/Quic/NIO/Connection/Handlers/PacketProtectorHandler.swift
@@ -45,75 +45,16 @@ final class PacketProtectorHandler: ChannelDuplexHandler {
     public typealias OutboundOut = ByteBuffer
 
     private let perspective: EndpointRole
+    private let originalDCID: ConnectionID
     private let scid: ConnectionID
 
     internal var initialKeys: PacketProtector
     internal var handshakeKeys: PacketProtector
     internal var trafficKeys: TrafficKeyRing
     private var storedContext: ChannelHandlerContext!
-
     private let remoteAddress: SocketAddress
-
-    /// Traffic Key Ring
-    /// Attempts to handle
-    /// https://datatracker.ietf.org/doc/html/rfc9001#section-6
-    struct TrafficKeyRing {
-        var currentKeyPhase: KeyPhase
-        private(set) var cumulativePhase: UInt64 = 0
-        private var trafficKeysPhase0: PacketProtector
-        private var trafficKeysPhase1: PacketProtector
-
-        init(version: Version) {
-            self.currentKeyPhase = .not
-            self.trafficKeysPhase0 = PacketProtector(epoch: .Application, version: version)
-            self.trafficKeysPhase1 = PacketProtector(epoch: .Application, version: version)
-        }
-
-        var currentKeys: PacketProtector {
-            self.keysFor(self.currentKeyPhase)
-        }
-
-        func keysFor(_ kp: KeyPhase) -> PacketProtector {
-            switch kp {
-                case .not:
-                    return self.trafficKeysPhase0
-                case .yes:
-                    return self.trafficKeysPhase1
-            }
-        }
-
-        mutating func installKeySet(suite: CipherSuite, secret: [UInt8], for mode: EndpointRole, ourPerspective: EndpointRole) throws {
-            guard self.trafficKeysPhase1.opener == nil && self.trafficKeysPhase1.sealer == nil else { print("Can't install KeySets after Key Ring initialization. Use updateKeys() instead."); throw Errors.Crypto(0) }
-            try self.trafficKeysPhase0.installKeySet(suite: suite, secret: secret, for: mode, ourPerspective: ourPerspective)
-        }
-
-        /// This method uses the existing keys to prepare a new set of traffic keys beloging to the new Key Phase.
-        /// This method will throw if the keys from the previous phase haven't been dropped yet.
-        /// Upon generating a new key set for the next key phase, this method will toggle our current traffic key phase and begin using the new keys.
-        mutating func updateKeys() throws {
-            switch self.currentKeyPhase {
-                case .not:
-                    guard self.trafficKeysPhase1.opener == nil && self.trafficKeysPhase1.sealer == nil else { throw Errors.Crypto(0) }
-                    guard self.trafficKeysPhase0.opener != nil && self.trafficKeysPhase0.sealer != nil else { throw Errors.Crypto(0) }
-                    try self.trafficKeysPhase1.updateKeys(using: self.trafficKeysPhase0)
-                case .yes:
-                    guard self.trafficKeysPhase0.opener == nil && self.trafficKeysPhase0.sealer == nil else { throw Errors.Crypto(0) }
-                    guard self.trafficKeysPhase1.opener != nil && self.trafficKeysPhase1.sealer != nil else { throw Errors.Crypto(0) }
-                    try self.trafficKeysPhase0.updateKeys(using: self.trafficKeysPhase1)
-            }
-            self.currentKeyPhase.toggle()
-            self.cumulativePhase += 1
-        }
-
-        public mutating func dropKeysForPreviousPhase() {
-            switch self.currentKeyPhase {
-                case .not:
-                    self.trafficKeysPhase1.dropKeys()
-                case .yes:
-                    self.trafficKeysPhase0.dropKeys()
-            }
-        }
-    }
+    private var version: Version
+    private var state: StateMachine
 
     private var canFlushHandshakeBuffer: Bool = false {
         didSet { if self.canFlushHandshakeBuffer && self.encryptedHandshakeBuffer.readableBytes > 0 && self.handshakeKeys.opener != nil { self.decryptAndFlushHandshakeBuffer() } }
@@ -127,14 +68,18 @@ final class PacketProtectorHandler: ChannelDuplexHandler {
 
     internal var encryptedTrafficBuffer: ByteBuffer = ByteBuffer()
 
-    init(initialDCID dcid: ConnectionID, scid: ConnectionID, version: Version, perspective: EndpointRole, remoteAddress: SocketAddress) {
+    init(initialDCID dcid: ConnectionID, scid: ConnectionID, versions: [Version], perspective: EndpointRole, remoteAddress: SocketAddress) {
+        guard !versions.isEmpty else { fatalError("Supported Versions can't be empty") }
         self.perspective = perspective
         self.scid = scid
+        self.originalDCID = dcid
         self.remoteAddress = remoteAddress
+        self.state = StateMachine(supportedVersions: versions)
+        self.version = versions.first!
         // Generate Initial Key Sets
-        self.initialKeys = try! version.newInitialAEAD(connectionID: dcid, perspective: perspective)
-        self.handshakeKeys = PacketProtector(epoch: .Handshake, version: version)
-        self.trafficKeys = TrafficKeyRing(version: version)
+        self.initialKeys = try! self.version.newInitialAEAD(connectionID: dcid, perspective: perspective)
+        self.handshakeKeys = PacketProtector(epoch: .Handshake, version: self.version)
+        self.trafficKeys = TrafficKeyRing(version: self.version)
     }
 
     public func handlerAdded(context: ChannelHandlerContext) {
@@ -151,6 +96,27 @@ final class PacketProtectorHandler: ChannelDuplexHandler {
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         var buffer = self.unwrapInboundIn(data)
+
+        if self.state.isNegotiatingVersion {
+            do {
+                if let versionNegotiationPacket = buffer.readVersionNegotiationPacket() {
+                    // We received a Version Negotiation Packet
+                    try self.state.processVersionNegotiationPacket(versionNegotiationPacket)
+                    // This updates our Keys
+                    try self.updateVersion()
+                    // Let our state handler know we've negotiated a different version
+                    context.fireUserInboundEventTriggered(ConnectionChannelEvent.VersionNegotiated(version: self.version))
+                    // The VersionNegotiationPacket should be this entire Datagram so we can return / stop processing here.
+                    return
+                } else {
+                    // The server is okay with our proposed Version
+                    try self.state.acceptedVersion()
+                    // Go ahead and process inbound packets as usual...
+                }
+            } catch {
+                context.fireUserInboundEventTriggered(ConnectionChannelEvent.FailedVersionNegotiation(error: "\(error)"))
+            }
+        }
 
         print("PacketProtectorHandler[\(self.perspective)]::ChannelRead::Envelope: \(buffer.readableBytes) bytes")
 
@@ -349,6 +315,17 @@ final class PacketProtectorHandler: ChannelDuplexHandler {
         }
     }
 
+    private func updateVersion() throws {
+        guard case .versionNegotiation(let vnState) = self.state.state else { print("Can't update Version from state `\(self.state.state)`"); throw Errors.UnsupportedVersion }
+        guard let negotiatedVersion = vnState.negotiatedVersion else { print("Failed to determine negotiated version"); throw Errors.UnsupportedVersion }
+        print("PacketProtectorHandler[\(self.perspective)]::Attempting to update to Version: \(negotiatedVersion)")
+        self.version = negotiatedVersion
+        self.initialKeys = try negotiatedVersion.newInitialAEAD(connectionID: self.originalDCID, perspective: self.perspective)
+        self.handshakeKeys = PacketProtector(epoch: .Handshake, version: negotiatedVersion)
+        self.trafficKeys = TrafficKeyRing(version: negotiatedVersion)
+        try self.state.doneUpdatingVersion()
+    }
+
     private func decryptAndFlushHandshakeBuffer() {
         print("PacketProtectorHandler[\(self.perspective)]::DecryptAndFlushHandshakeBuffer")
         while self.encryptedHandshakeBuffer.readableBytes > 0 {
@@ -399,5 +376,164 @@ final class PacketProtectorHandler: ChannelDuplexHandler {
         }
 
         // TODO: Check if short packet is long enough...
+    }
+}
+
+extension PacketProtectorHandler {
+    /// Traffic Key Ring
+    /// Attempts to handle
+    /// https://datatracker.ietf.org/doc/html/rfc9001#section-6
+    struct TrafficKeyRing {
+        var currentKeyPhase: KeyPhase
+        private(set) var cumulativePhase: UInt64 = 0
+        private var trafficKeysPhase0: PacketProtector
+        private var trafficKeysPhase1: PacketProtector
+
+        init(version: Version) {
+            self.currentKeyPhase = .not
+            self.trafficKeysPhase0 = PacketProtector(epoch: .Application, version: version)
+            self.trafficKeysPhase1 = PacketProtector(epoch: .Application, version: version)
+        }
+
+        var currentKeys: PacketProtector {
+            self.keysFor(self.currentKeyPhase)
+        }
+
+        func keysFor(_ kp: KeyPhase) -> PacketProtector {
+            switch kp {
+                case .not:
+                    return self.trafficKeysPhase0
+                case .yes:
+                    return self.trafficKeysPhase1
+            }
+        }
+
+        mutating func installKeySet(suite: CipherSuite, secret: [UInt8], for mode: EndpointRole, ourPerspective: EndpointRole) throws {
+            guard self.trafficKeysPhase1.opener == nil && self.trafficKeysPhase1.sealer == nil else { print("Can't install KeySets after Key Ring initialization. Use updateKeys() instead."); throw Errors.Crypto(0) }
+            try self.trafficKeysPhase0.installKeySet(suite: suite, secret: secret, for: mode, ourPerspective: ourPerspective)
+        }
+
+        /// This method uses the existing keys to prepare a new set of traffic keys beloging to the new Key Phase.
+        /// This method will throw if the keys from the previous phase haven't been dropped yet.
+        /// Upon generating a new key set for the next key phase, this method will toggle our current traffic key phase and begin using the new keys.
+        mutating func updateKeys() throws {
+            switch self.currentKeyPhase {
+                case .not:
+                    guard self.trafficKeysPhase1.opener == nil && self.trafficKeysPhase1.sealer == nil else { throw Errors.Crypto(0) }
+                    guard self.trafficKeysPhase0.opener != nil && self.trafficKeysPhase0.sealer != nil else { throw Errors.Crypto(0) }
+                    try self.trafficKeysPhase1.updateKeys(using: self.trafficKeysPhase0)
+                case .yes:
+                    guard self.trafficKeysPhase0.opener == nil && self.trafficKeysPhase0.sealer == nil else { throw Errors.Crypto(0) }
+                    guard self.trafficKeysPhase1.opener != nil && self.trafficKeysPhase1.sealer != nil else { throw Errors.Crypto(0) }
+                    try self.trafficKeysPhase0.updateKeys(using: self.trafficKeysPhase1)
+            }
+            self.currentKeyPhase.toggle()
+            self.cumulativePhase += 1
+        }
+
+        public mutating func dropKeysForPreviousPhase() {
+            switch self.currentKeyPhase {
+                case .not:
+                    self.trafficKeysPhase1.dropKeys()
+                case .yes:
+                    self.trafficKeysPhase0.dropKeys()
+            }
+        }
+    }
+}
+
+extension PacketProtectorHandler {
+    /// A State Machine that the PacketProtectorHandler can use to handle Version Negotiation
+    struct StateMachine {
+        private(set) var state: State
+
+        public var isNegotiatingVersion: Bool {
+            switch self.state {
+                case .versionNegotiation: return true
+                default: return false
+            }
+        }
+
+        enum State {
+            case versionNegotiation(VersionNegotiationState)
+            case active(ActiveState)
+            case incompatible
+        }
+
+        struct VersionNegotiationState {
+            let versions: [Version]
+            var negotiatedVersion: Version? = nil
+
+            mutating func negotiatedVersion(_ version: Version) throws {
+                guard self.versions.contains(version) else { print("Chosen Version is not a supported Version"); throw Errors.UnsupportedVersion }
+                guard self.negotiatedVersion == nil else { print("A version has already been negotiated"); throw Errors.UnsupportedVersion }
+                self.negotiatedVersion = version
+            }
+        }
+
+        struct ActiveState {
+            let version: Version
+
+            init(previous: VersionNegotiationState) {
+                guard let negotiatedVersion = previous.negotiatedVersion else { fatalError("Can't enter Active State without a negotiated Version") }
+                self.version = negotiatedVersion
+            }
+        }
+
+        init(supportedVersions: [Version]) {
+            self.state = .versionNegotiation(VersionNegotiationState(versions: supportedVersions))
+        }
+
+        init(negotiatiedVersion: Version) {
+            self.state = .active(ActiveState(previous: VersionNegotiationState(versions: [], negotiatedVersion: negotiatiedVersion)))
+        }
+
+        public mutating func acceptedVersion() throws {
+            switch self.state {
+                case .versionNegotiation(var vnState):
+                    guard let acceptedVersion = vnState.versions.first else { throw Errors.UnsupportedVersion }
+                    try vnState.negotiatedVersion(acceptedVersion)
+                    self.state = .active(ActiveState(previous: vnState))
+                    print("Accepted Active Version: \(acceptedVersion)")
+                case .active, .incompatible:
+                    throw Errors.UnsupportedVersion
+            }
+        }
+
+        public mutating func processVersionNegotiationPacket(_ vnPacket: VersionNegotiationPacket) throws {
+            switch self.state {
+                case .versionNegotiation(var vnState):
+                    var match: Version?
+                    for desiredVersion in vnState.versions {
+                        if vnPacket.versions.contains(desiredVersion) {
+                            // We've found a Version that we both agree with...
+                            print("Selecting Version: \(desiredVersion)")
+                            match = desiredVersion
+                            break
+                        }
+                    }
+
+                    if let match = match {
+                        try vnState.negotiatedVersion(match)
+                        self.state = .versionNegotiation(vnState)
+                        print("Negotiated Version: \(match)")
+                    } else {
+                        print("No Supported Version Overlap with Server. Entering State -> Incompatible")
+                        self.state = .incompatible
+                    }
+
+                case .active, .incompatible:
+                    throw Errors.UnsupportedVersion
+            }
+        }
+
+        public mutating func doneUpdatingVersion() throws {
+            switch self.state {
+                case .versionNegotiation(let vnState):
+                    self.state = .active(ActiveState(previous: vnState))
+                default:
+                    throw Errors.UnsupportedVersion
+            }
+        }
     }
 }

--- a/Sources/Quic/NIO/Connection/Handlers/ServerHandler.swift
+++ b/Sources/Quic/NIO/Connection/Handlers/ServerHandler.swift
@@ -110,7 +110,7 @@ final class QUICServerHandler: ChannelDuplexHandler, NIOSSLQuicDelegate {
         self.scid = ConnectionID(randomOfLength: 5) //sourceID ?? ConnectionID(randomOfLength: 8)
 
         // Initialize our PacketProtectorHandler
-        self.packetProtectorHandler = PacketProtectorHandler(initialDCID: destinationID, scid: self.scid, version: version, perspective: .server, remoteAddress: remoteAddress)
+        self.packetProtectorHandler = PacketProtectorHandler(initialDCID: destinationID, scid: self.scid, versions: [version], perspective: .server, remoteAddress: remoteAddress)
         self.ackHandler = ACKChannelHandler()
 
         // Update the transport params with the original destination connection id

--- a/Sources/Quic/NIO/Connection/Handlers/ServerHandler.swift
+++ b/Sources/Quic/NIO/Connection/Handlers/ServerHandler.swift
@@ -200,7 +200,7 @@ final class QUICServerHandler: ChannelDuplexHandler, NIOSSLQuicDelegate {
                         guard let clientHello = try? ClientHello(header: [], payload: &clientHelloBytes) else { context.fireErrorCaught(Errors.InvalidPacket); return }
                         print(clientHello)
                         print("Quic Params")
-                        var extBuf = ByteBuffer(bytes: clientHello.extensions.first(where: { $0.type == [0x00, 0x39] })!.value)
+                        var extBuf = ByteBuffer(bytes: clientHello.extensions.first(where: { $0.type == [0x00, 0x39] || $0.type == [0xff, 0xa5] })!.value)
                         let quicParams = try! TransportParams.decode(&extBuf, perspective: .server)
                         print(quicParams)
 

--- a/Sources/Quic/NIO/Connection/Handlers/ServerHandler.swift
+++ b/Sources/Quic/NIO/Connection/Handlers/ServerHandler.swift
@@ -414,6 +414,14 @@ final class QUICServerHandler: ChannelDuplexHandler, NIOSSLQuicDelegate {
             print("QUICServerHandler::UserInboundEventTriggered::TODO::Got our key update finished message!")
             print(keyUpdateFinishedMessage)
             self.packetProtectorHandler.dropTrafficKeysForPreviousPhase()
+        } else if let versionNegotiated = event as? ConnectionChannelEvent.VersionNegotiated {
+            print("QUICServerHandler::UserInboundEventTriggered::ServerHandler Doesn't Support Version Negotiation (the Connection is only established when we support the version being requested)!")
+            print(versionNegotiated)
+            context.close(mode: .all, promise: nil)
+        } else if let versionNegotiationFailed = event as? ConnectionChannelEvent.FailedVersionNegotiation {
+            print("QUICServerHandler::UserInboundEventTriggered::ServerHandler Doesn't Support Version Negotiation (the Connection is only established when we support the version being requested)")
+            print(versionNegotiationFailed)
+            context.close(mode: .all, promise: nil)
         }
         // We consume this event. No need to pass it along.
     }

--- a/Sources/Quic/QuicTypes/Packets/VersionNegotiationPacket.swift
+++ b/Sources/Quic/QuicTypes/Packets/VersionNegotiationPacket.swift
@@ -35,7 +35,17 @@ struct VersionNegotiationPacket: Packet {
     let header: VersionNegotiationHeader
     let versions: [Version]
 
+    /// This initializer is intended for outbound Version Negotiation Packets (auto fills the supported versions).
     init(destinationID: ConnectionID, sourceID: ConnectionID) {
+        self.header = VersionNegotiationHeader(
+            destinationID: destinationID,
+            sourceID: sourceID
+        )
+        self.versions = supportedVersions
+    }
+
+    /// This initializer is intended for Decoding inbound Version Negotiation Packets.
+    init(destinationID: ConnectionID, sourceID: ConnectionID, supportedVersions: [Version]) {
         self.header = VersionNegotiationHeader(
             destinationID: destinationID,
             sourceID: sourceID

--- a/Sources/Quic/QuicTypes/Version/Version.swift
+++ b/Sources/Quic/QuicTypes/Version/Version.swift
@@ -22,12 +22,14 @@ struct Version: RawRepresentable {
     }
 }
 
+/// https://www.iana.org/assignments/quic/quic.xhtml
 extension Version {
-    /// https://datatracker.ietf.org/doc/draft-ietf-quic-v2/
-    static let version2: Version = 2
-    /// https://datatracker.ietf.org/doc/html/rfc9001
-    static let version1: Version = 1
-    /// https://datatracker.ietf.org/doc/html/draft-ietf-quic-tls-29
+    /// https://www.rfc-editor.org/rfc/rfc9369.html
+    /// TODO: We can set version2 to the incorrect identifier (0x2) during testing in order to force Version Negotiations to take place.
+    static let version2: Version = 0x6b33_43cf // 0x2
+    /// https://datatracker.ietf.org/doc/html/rfc9000
+    static let version1: Version = 0x1
+    /// https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29
     static let versionDraft29: Version = 0xff00_001d
 }
 

--- a/Tests/QuicTests/NIOTests/GoInteropTests/QuicClientGoServerHandshakeTests.swift
+++ b/Tests/QuicTests/NIOTests/GoInteropTests/QuicClientGoServerHandshakeTests.swift
@@ -182,7 +182,7 @@ final class QUICExternalDialClientTests: XCTestCase {
         let sslClientContext = try! NIOSSLContext(configuration: configuration)
 
         // Configure our Handlers
-        self.quicClientHandler = try! QUICClientHandler(SocketAddress(ipAddress: "127.0.0.1", port: 6121), version: self.version, destinationID: self.dcid, sourceID: self.scid, tlsContext: sslClientContext)
+        self.quicClientHandler = try! QUICClientHandler(SocketAddress(ipAddress: "127.0.0.1", port: 4242), versions: [.version1], destinationID: self.dcid, sourceID: self.scid, tlsContext: sslClientContext)
         self.clientQuiesceEventRecorder = QuiesceEventRecorder()
         self.clientErrorHandler = ErrorEventLogger()
 

--- a/Tests/QuicTests/NIOTests/HandshakeTests.swift
+++ b/Tests/QuicTests/NIOTests/HandshakeTests.swift
@@ -135,7 +135,7 @@ final class QUICHandshakeTests: XCTestCase {
         let sslClientContext = try! NIOSSLContext(configuration: configuration)
 
         // Client QUIC State Handler
-        let clientHandler = try! QUICClientHandler(SocketAddress(ipAddress: "127.0.0.1", port: 0), version: self.version, destinationID: self.dcid, sourceID: self.scid, tlsContext: sslClientContext)
+        let clientHandler = try! QUICClientHandler(SocketAddress(ipAddress: "127.0.0.1", port: 0), versions: [self.version], destinationID: self.dcid, sourceID: self.scid, tlsContext: sslClientContext)
 
         // Configure Server TLS
         var serverConfiguration = TLSConfiguration.makeServerConfiguration(
@@ -258,7 +258,7 @@ final class QUICHandshakeTests: XCTestCase {
     /// Takes about 5ms to generate a Client InitialPacket
     func testHandshake2() throws {
         throw XCTSkip("This integration test is skipped by default")
-        
+
         try self.backToBack.interactInMemory()
 
         print("Done???")

--- a/Tests/QuicTests/NIOTests/PacketProtectorHandlerTests.swift
+++ b/Tests/QuicTests/NIOTests/PacketProtectorHandlerTests.swift
@@ -26,7 +26,7 @@ final class PacketProtectorHandlerTests: XCTestCase {
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.packetProtectorHandler = try! PacketProtectorHandler(initialDCID: self.odcid, scid: self.scid, version: .version1, perspective: .client, remoteAddress: SocketAddress(ipAddress: "127.0.0.1", port: 1))
+        self.packetProtectorHandler = try! PacketProtectorHandler(initialDCID: self.odcid, scid: self.scid, versions: [.version1], perspective: .client, remoteAddress: SocketAddress(ipAddress: "127.0.0.1", port: 1))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.packetProtectorHandler).wait())
 
         // this activates the channel
@@ -108,7 +108,7 @@ final class PacketProtectorHandlerTests2: XCTestCase {
 
     override func setUp() {
         self.channel = EmbeddedChannel()
-        self.packetProtectorHandler = try! PacketProtectorHandler(initialDCID: self.odcid, scid: self.scid, version: .version1, perspective: .client, remoteAddress: SocketAddress(ipAddress: "127.0.0.1", port: 1))
+        self.packetProtectorHandler = try! PacketProtectorHandler(initialDCID: self.odcid, scid: self.scid, versions: [.version1], perspective: .client, remoteAddress: SocketAddress(ipAddress: "127.0.0.1", port: 1))
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.packetProtectorHandler).wait())
     }
 

--- a/Tests/QuicTests/NIOTests/TLSTests.swift
+++ b/Tests/QuicTests/NIOTests/TLSTests.swift
@@ -44,7 +44,7 @@ final class TLSClientInitialTests: XCTestCase {
         let sslContext = try! NIOSSLContext(configuration: configuration)
 
         self.channel = EmbeddedChannel()
-        self.quicClientHandler = try! QUICClientHandler(SocketAddress(ipAddress: "127.0.0.1", port: 0), version: self.version, destinationID: self.dcid, sourceID: self.scid, tlsContext: sslContext)
+        self.quicClientHandler = try! QUICClientHandler(SocketAddress(ipAddress: "127.0.0.1", port: 0), versions: [self.version], destinationID: self.dcid, sourceID: self.scid, tlsContext: sslContext)
         self.quiesceEventRecorder = QuiesceEventRecorder()
         self.errorHandler = ErrorEventLogger()
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(self.quicClientHandler).wait())


### PR DESCRIPTION
## Preliminary Support for Version Negotiation
[As described in RFC9000 - Section 6](https://datatracker.ietf.org/doc/html/rfc9000#name-version-negotiation)

### What
This PR adds preliminary support for version negotiation at the beginning of a Connection.

### How
**Server Side**
   - The ConnectionMuxer responds with a VersionNegotiationPacket when it encounters an InitialPacket created with an unsupported version.
> **Note**
> Server Side Connections are only instantiated with supported versions (there are no version negotiation events for server side connections)

**Client Side**
   - The connection is established using the first `Version` passed into the `QUICClientHandler`'s initializer.
   - If we receive a `VersionNegotiationPacket` in response to our Initial Client Hello packet. 
       - The `PacketProtectorHandler` cycles through our supported versions and the servers supported versions searching for the best match.
          - `if` we find a Version match
             - The `PacketProtectorHandler` fires a `VersionNegotiated` event down the pipeline for our `StateHandler` to receive. 
             - The `Statehandler` reinitializes the NIOSSLHandler with the correct version dependent params and writes the newly generated ClientHello out to be padded and encrypted by the `PacketProtectorHandler` using the newly generated keys.
          - `else` (we don't have a supported version overlap)
             - The `PacketProtectorHandler` enters the `.incompatible` state and fires a `VersionNegotiationFailed` event down the pipeline for the `StateHandler` to receive.
             - The `StateHandler` is responsible for closing / terminating the connection upon receiving the event. 
   - Otherwise the server agreed to our proposed version and the connection continues Handshaking normally.
   

### Testing it
**Swift Server <--> Go Client**
Using the Go example code provided in the [Go Client Handshake Test](https://github.com/swift-quic/swift-quic/blob/develop/Tests/QuicTests/NIOTests/GoInteropTests/QuicServerGoClientHandshakeTests.swift) file. The Go Client will attempt to establish a connection using `.version1`. If we change our supported versions in the Quic file to only `.versionDraft29` then we will trigger a Version Negotiation to take place. The Go Client, will re send the Initial Client Hello packet using the `versionDraft29` spec and the connection will proceed as usual.

**Swift Client <--> Go Server**
Using the Go example code provided in the [Go Server Handshake Test](https://github.com/swift-quic/swift-quic/blob/develop/Tests/QuicTests/NIOTests/GoInteropTests/QuicClientGoServerHandshakeTests.swift) file. The Go Server supports `.version2`, `.version1` and `.versionDraft29`. So we need to provide a fake / unknown version in order trigger a version negotiation. If we change `.version2`'s tag from the correct identifier `0x6b33_43cf` to an incorrect identifier of `0x2` then attempt to connect to the Go Server using the supported `versions: [.version2, .version1]`. We'll receive a `VersionNegotiationPacket` in response to the unknown version `0x2` and our `PacketProtectorHandler` will match on the next best supported version `.version1`. At which point the logic stated above plays out and the connection is established using the negotiated version, `.version1`.